### PR TITLE
typo that messes up global/local parameter tab switching

### DIFF
--- a/app/host/templates/host/sed_inference_card.html
+++ b/app/host/templates/host/sed_inference_card.html
@@ -6,7 +6,7 @@
 <h5>Host SED inference</h5>
 <ul class="nav nav-tabs card-header-tabs" id="myTab" role="tablist">
     <li class="nav-item" role="presentation">
-        <button class="nav-link active" id="global-params-tab" data-bs-toggle="tab" data-bs-target="#global-parmas" type="button" role="tab" aria-controls="global-params" aria-selected="false">Global</button>
+        <button class="nav-link active" id="global-params-tab" data-bs-toggle="tab" data-bs-target="#global-params" type="button" role="tab" aria-controls="global-params" aria-selected="false">Global</button>
     </li>
     <li class="nav-item" role="presentation">
         <button class="nav-link" id="local-params-tab" data-bs-toggle="tab" data-bs-target="#local-params" type="button" role="tab" aria-controls="local-params" aria-selected="true">Local</button>


### PR DESCRIPTION
Fixes #  <!-- If your PR relates to an issue mention it here e.g. Issue #34, Issue #56 -->.

## Description of the Change
typo was messing up SED inference tabs

## Checklist

Please check all that apply to your proposed changes

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] HTML code change
- [ ] Added package dependency
- [ ] Added data
- [ ] Changed django model
- [ ] Documentation change
- [ ] Added or changed TaskRunner

### **Additional context**
<!-- Add any other context or additional information about the problem here.-->
