### PR TITLE
Limit Docker Compose port binding to localhost

### DIFF
--- a/docker/docker-compose.blast_base.yml
+++ b/docker/docker-compose.blast_base.yml
@@ -45,7 +45,7 @@ services:
     volumes:
       - blast-db:/var/lib/mysql/
     ports:
-      - 3306:${DATABASE_PORT}
+      - 127.0.0.1:3306:${DATABASE_PORT}
     env_file:
       - ../env/.env.default
       - ../env/.env.ci
@@ -56,7 +56,7 @@ services:
       - django-static:/static
       - blast-data:/data
     ports:
-      - 80:${WEB_SERVER_PORT}
+      - 127.0.0.1:80:${WEB_SERVER_PORT}
     env_file:
       - ../env/.env.default
       - ../env/.env.dev
@@ -67,7 +67,7 @@ services:
     volumes:
       - blast-db:/var/lib/mysql/
     ports:
-      - 3306:${DATABASE_PORT}
+      - 127.0.0.1:3306:${DATABASE_PORT}
     env_file:
       - ../env/.env.default
       - ../env/.env.dev

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       file: docker-compose.blast_base.yml
       service: ${BLAST_IMAGE}
     ports:
-      - 8000:${WEB_APP_PORT}
+      - 127.0.0.1:8000:${WEB_APP_PORT}
     profiles: ["full_prod", "slim_prod"]
     env_file:
       - ../env/.env.default
@@ -40,8 +40,8 @@ services:
     restart: always
     image: rabbitmq:3.10.6-management-alpine
     ports:
-      - 5672:${MESSAGE_BROKER_PORT}
-      - 15672:${MESSAGE_BROKER_MANAGEMENT_PORT}
+      - 127.0.0.1:5672:${MESSAGE_BROKER_PORT}
+      - 127.0.0.1:15672:${MESSAGE_BROKER_MANAGEMENT_PORT}
     volumes:
       - ../data/rabbitmq_data:/data
       - ../data/rabbitmq_data/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
@@ -81,7 +81,7 @@ services:
       service: ${BLAST_IMAGE}
     command: bash entrypoints/docker-entrypoint.flower.sh
     ports:
-      - "8888:${FLOWER_PORT}"
+      - 127.0.0.1:8888:${FLOWER_PORT}
     env_file:
       - ../env/.env.default
       - ../env/.env.dev
@@ -91,7 +91,7 @@ services:
       file: docker-compose.blast_base.yml
       service: ${BLAST_IMAGE}
     ports:
-      - "8000:${WEB_APP_PORT}"
+      - 127.0.0.1:8000:${WEB_APP_PORT}
     networks:
       default:
         aliases:
@@ -147,7 +147,7 @@ services:
       service: ${BLAST_IMAGE}
     command: bash entrypoints/docker-entrypoint.app.sh
     ports:
-      - 8000:${WEB_APP_PORT}
+      - 127.0.0.1:8000:${WEB_APP_PORT}
     profiles: ["full_dev", "slim_dev", "batch"]
     environment:
       - "DEV_MODE=1"


### PR DESCRIPTION
## Description of the Change

[Docker can bypass firewalls](https://docs.docker.com/network/packet-filtering-firewalls/#docker-and-ufw), making it all the more important to [include only localhost specifically in the ports spec](https://docs.docker.com/compose/compose-file/05-services/#ports). This PR binds ports only to localhost.