### PR TITLE
Restore MEDIA_ROOT in settings.py to avoid SuspiciousFileOperation error

### DIFF
--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -151,6 +151,7 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 
 MEDIA_URL = "/cutouts/"
+MEDIA_ROOT = os.path.join(os.path.dirname(BASE_DIR), "data")
 
 DUSTMAPS_DATA_ROOT = os.environ.get("DUSTMAPS_DATA_ROOT", "/data/dustmaps")  # noqa
 CUTOUT_ROOT = os.environ.get("CUTOUT_ROOT", "/data/cutout_cdn")  # noqa


### PR DESCRIPTION
## Description of the Change

File downloads were failing after the removal of the MEDIA_ROOT Django setting (commit d6f9000df81efda31bd9be853eaf40ea6743754a) due to the file path `/data/...` being outside the app root `/app`, causing at SuspiciousFileOperation exception. This restores that setting.

Unit tests pass at commit 83f233d.