### PR TITLE
272 bug tns api response reset time not always integer

### DIFF
--- a/app/host/templates/host/results.html
+++ b/app/host/templates/host/results.html
@@ -1,7 +1,7 @@
 {% extends 'host/base.html' %}
 {% load latexify %}
 
-{% block title %} Results {% endblock %}
+{% block title %} {{transient.name}} results {% endblock %}
 {% block script %} {{ bokeh_cutout_script | safe }} {{ bokeh_sed_local_script | safe }} {{ bokeh_sed_global_script | safe }}  {% endblock %}
 
 {% load crispy_forms_tags %}

--- a/app/host/transient_name_server.py
+++ b/app/host/transient_name_server.py
@@ -44,6 +44,12 @@ def query_tns(data, headers, search_url):
     response_status_good = response_id_code == 200
     data = response_json.get("data", {}) if response_status_good else []
     response_reset_time = response.headers['x-rate-limit-reset']
+    try:
+        response_reset_time = int(response_reset_time)
+    except ValueError:
+        # If the reset time is for some reason not an integer value, set to the default value.
+        # See https://www.wis-tns.org/comment/26286#comment-26286 for details.
+        response_reset_time = 60
 
     response_return = {
         "response_message": response_message,


### PR DESCRIPTION
- Fixes #272 . 
- Adds the transient name to the web browser tab when viewing results pages so that if multiple transients are open they are distinguishable.