### PR TITLE
Update notes on units in documentation

### DIFF
--- a/docs/usage/web_api.rst
+++ b/docs/usage/web_api.rst
@@ -163,7 +163,7 @@ which can either be "16", "50" ot "84"
 
 * :code:`chains_file` - MCMC chains for each parameter; files can be downloaded with the URL path :code:`<base_blast_url>/download_chains/<transient_name>/<aperture_type>`
 * :code:`percentiles_file` - 16,50,84th percentiles for all parameters in the prospector-alpha model; files can be downloaded with the URL path :code:`<base_blast_url>/download_percentiles/<transient_name>/<aperture_type>`
-* :code:`model_file` - best-fit spectrum, photometry, and uncertainties; files can be downloaded with the URL path :code:`<base_blast_url>/download_modelfit/<transient_name>/<aperture_type>`
+* :code:`model_file` - best-fit spectrum, photometry, and uncertainties (downloaded in units of maggies); files can be downloaded with the URL path :code:`<base_blast_url>/download_modelfit/<transient_name>/<aperture_type>`
 
 
 SED filtering options


### PR DESCRIPTION
Fixes #  <!-- If your PR relates to an issue mention it here e.g. Issue #34, Issue #56 -->.

## Description of the Change

Added note that when downloading best fit spectra, the units are in maggies!

## Checklist

Please check all that apply to your proposed changes

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [ ] HTML code change
- [ ] Added package dependency
- [ ] Added data
- [ ] Changed django model
- [ x] Documentation change
- [ ] Added or changed TaskRunner

### **Additional context**
<!-- Add any other context or additional information about the problem here.-->
