### PR TITLE
Use a periodic task to render a statically served home page

### DIFF
--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -12,7 +12,7 @@ https://docs.djangoproject.com/en/3.2/ref/settings/
 import os
 from pathlib import Path
 
-APP_VERSION = '1.0.1'
+APP_VERSION = '1.0.2'
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -12,7 +12,7 @@ https://docs.djangoproject.com/en/3.2/ref/settings/
 import os
 from pathlib import Path
 
-APP_VERSION = '1.0.2'
+APP_VERSION = '1.0.4'
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -35,7 +35,7 @@ SILKY_INTERCEPT_PERCENT = int(os.environ.get("SILKY_INTERCEPT_PERCENT", "0"))
 HOSTNAMES = os.environ.get("DJANGO_HOSTNAMES", "localhost").split(",")
 ALLOWED_HOSTS = ["*"]
 CORS_ORIGIN_WHITELIST = ["*"]
-CSRF_TRUSTED_ORIGINS = ["http://localhost", "http://localhost:8000"]
+CSRF_TRUSTED_ORIGINS = ["http://localhost", "http://localhost:8000", "http://localhost:4000"]
 for hostname in HOSTNAMES:
     CSRF_TRUSTED_ORIGINS.append(f"""https://{hostname}""")
 CSRF_COOKIE_SECURE = True

--- a/app/entrypoints/setup_initial_periodic_tasks.py
+++ b/app/entrypoints/setup_initial_periodic_tasks.py
@@ -1,7 +1,7 @@
 from django_celery_beat.models import IntervalSchedule
 from django_celery_beat.models import PeriodicTask
 from host.tasks import periodic_tasks
-from django.core.exceptions import ValidationError
+from host.views import update_home_page_statistics
 
 for taskrunner in periodic_tasks:
     task = taskrunner.task_name
@@ -20,3 +20,22 @@ for taskrunner in periodic_tasks:
             task=taskrunner.task_function_name,
             enabled=taskrunner.task_initially_enabled,
         )
+
+# Render the initial version of the static home page
+update_home_page_statistics()
+
+# Schedule a periodic task to update the rendered home page
+interval, created = IntervalSchedule.objects.get_or_create(
+    every=300, period=IntervalSchedule.SECONDS
+)
+search = PeriodicTask.objects.filter(
+    name='render_home_page',
+)
+if search:
+    search.delete()
+PeriodicTask.objects.create(
+    interval=interval,
+    name='render_home_page',
+    task='host.views.update_home_page_statistics',
+    enabled=True,
+)

--- a/app/host/views.py
+++ b/app/host/views.py
@@ -56,8 +56,7 @@ def filter_transient_categories(qs, value, task_register=None):
                     task__name="Local aperture photometry",
                     status__message="processed",
                 ).values("transient")
-            )
-            | Q(
+            ) | Q(
                 pk__in=task_register.filter(
                     task__name="Global aperture photometry",
                     status__message="processed",
@@ -71,8 +70,7 @@ def filter_transient_categories(qs, value, task_register=None):
                     task__name="Local host SED inference",
                     status__message="processed",
                 ).values("transient")
-            )
-            | Q(
+            ) | Q(
                 pk__in=task_register.filter(
                     task__name="Global host SED inference",
                     status__message="processed",
@@ -243,14 +241,54 @@ def results(request, slug):
     )
     # ugly, but effective?
     local_sed_results, global_sed_results = (), ()
-    for param,var,ptype in zip(
-            ["{\\rm log}_{10}(M_{\\ast}/M_{\odot})\,", "{\\rm log}_{10}({\\rm SFR})", "{\\rm log}_{10}({\\rm sSFR})", "{\\rm stellar\ age}", "{\\rm log}_{10}(Z_{\\ast}/Z_{\odot})", "{\\rm log}_{10}(Z_{gas}/Z_{\odot})\,",
-             "\\tau_2", "\delta", "\\tau_1/\\tau_2", "Q_{PAH}", "U_{min}", "{\\rm log}_{10}(\gamma_e)\,",
-             "{\\rm log}_{10}(f_{AGN})\,", "{\\rm log}_{10}(\\tau_{AGN})\,"],
-            ["log_mass", "log_sfr", "log_ssfr", "log_age", "logzsol","gas_logz",
-             "dust2","dust_index","dust1_fraction","duste_qpah", "duste_umin", "log_duste_gamma",
-             "log_fagn","log_agn_tau"],
-            ["normal","normal","normal","normal","Metallicity","Metallicity","Dust","Dust","Dust","Dust","Dust","Dust","AGN","AGN"]
+    for param, var, ptype in zip(
+        [
+            "{\\rm log}_{10}(M_{\\ast}/M_{\odot})\,",  # noqa
+            "{\\rm log}_{10}({\\rm SFR})",  # noqa
+            "{\\rm log}_{10}({\\rm sSFR})",  # noqa
+            "{\\rm stellar\ age}",  # noqa
+            "{\\rm log}_{10}(Z_{\\ast}/Z_{\odot})",  # noqa
+            "{\\rm log}_{10}(Z_{gas}/Z_{\odot})\,",  # noqa
+            "\\tau_2",
+            "\delta",  # noqa
+            "\\tau_1/\\tau_2",
+            "Q_{PAH}",
+            "U_{min}",
+            "{\\rm log}_{10}(\gamma_e)\,",  # noqa
+            "{\\rm log}_{10}(f_{AGN})\,",  # noqa
+            "{\\rm log}_{10}(\\tau_{AGN})\,"  # noqa
+        ],
+        [
+            "log_mass",
+            "log_sfr",
+            "log_ssfr",
+            "log_age",
+            "logzsol",
+            "gas_logz",
+            "dust2",
+            "dust_index",
+            "dust1_fraction",
+            "duste_qpah",
+            "duste_umin",
+            "log_duste_gamma",
+            "log_fagn",
+            "log_agn_tau"
+        ],
+        [
+            "normal",
+            "normal",
+            "normal",
+            "normal",
+            "Metallicity",
+            "Metallicity",
+            "Dust",
+            "Dust",
+            "Dust",
+            "Dust",
+            "Dust",
+            "Dust",
+            "AGN",
+            "AGN"]
     ):
 
         if local_sed_obj.exists():
@@ -285,7 +323,7 @@ def results(request, slug):
                     sh.logsfr_tmax
                 ),
             )
-                
+
     if global_sed_obj.exists():
         for sh in global_sed_obj[0].logsfh.all():
             global_sfh_results += (
@@ -297,7 +335,7 @@ def results(request, slug):
                     sh.logsfr_tmax
                 ),
             )
-        
+
     if local_sed_obj.exists():
         local_sed_file = local_sed_obj[0].posterior.name
     else:

--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -12,6 +12,20 @@ volumes:
 
 services:
 
+  nginx:
+    extends:
+      file: docker-compose.yml
+      service: nginx
+    ports:
+      - 127.0.0.1:4000:${WEB_SERVER_PORT}
+    env_file:
+      - ../env/.env.default
+      - ../env/.env.dev
+    volumes:
+      - django-static:/static
+      - blast-data:/data
+      - ../nginx/default_slim.conf:/etc/nginx/conf.d/default.conf
+
   app:
     extends:
       file: docker-compose.yml

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,6 +11,21 @@ volumes:
     name: "blast-data"
 
 services:
+  nginx:
+    image: nginx:1.21-alpine
+    restart: always
+    networks:
+      - internal
+    volumes:
+      - django-static:/static
+      - blast-data:/data
+      - ../nginx/default.conf:/etc/nginx/conf.d/default.conf
+    profiles:
+      - "full_prod"
+      - "slim_prod"
+      - "full_dev"
+      - "slim_dev"
+
   app:
     image: ${BLAST_IMAGE:-registry.gitlab.com/ncsa-blast/kubernetes/blast:latest}
     command: bash entrypoints/docker-entrypoint.app.sh

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -7,6 +7,7 @@ server {
 
 	location / {
 		proxy_pass http://app/;
+		rewrite ^/$ /static/index.html last;
 	}
 
 	location /static/ {

--- a/nginx/default_slim.conf
+++ b/nginx/default_slim.conf
@@ -7,6 +7,7 @@ server {
 
 	location / {
 		proxy_pass http://app/;
+		rewrite ^/$ /static/index.html last;
 	}
 
 	location /static/ {


### PR DESCRIPTION
Fixes #271 

## Description of the Change

A new Celery Beat periodic task is defined to pre-render the home page content such that static files are served instead of querying the database and constructing the bar chart every time the page is requested. The rendered HTML file is stored with the other static files and served by NGINX proxy, bypassing the Django server entirely to improve performance. In development mode, it is possible to render the page on demand from the Django server by visiting http://localhost:8000, or it can be viewed statically through the NGINX server at http://localhost:4000.