### PR TITLE
aperture construction downloads the necessary files first

### DIFF
--- a/app/host/cutouts.py
+++ b/app/host/cutouts.py
@@ -82,6 +82,7 @@ def download_and_save_cutouts(
     fov=Quantity(0.1, unit="deg"),
     cutout_base_path=settings.CUTOUT_ROOT,
     overwrite=settings.CUTOUT_OVERWRITE,
+    filter_set=None
 ):
     """
     Download all available imaging from a list of surveys
@@ -103,7 +104,9 @@ def download_and_save_cutouts(
         as values.
     """
     processed_value = "processed"
-    for filter in Filter.objects.all():
+    if filter_set is None:
+        filter_set = Filter.objects.all()
+    for filter in filter_set:
         # Does cutout file exist on the local disk?
         save_dir = f"{cutout_base_path}/{transient.name}/{filter.survey.name}/"
         local_fits_path = save_dir + f"{filter.name}.fits"

--- a/app/host/tests/test_aperture_construction.py
+++ b/app/host/tests/test_aperture_construction.py
@@ -4,15 +4,18 @@ from django.test import TestCase
 
 from ..host_utils import build_source_catalog
 from ..host_utils import estimate_background
-from ..models import Transient
+from ..models import Transient, Filter
 from ..transient_tasks import GlobalApertureConstruction
-
+from ..cutouts import download_and_save_cutouts
 
 class TestApertureConstruction(TestCase):
 
     def test_aperture_construction(self):
         transient = Transient.objects.get(name="2010H")
-
+        download_and_save_cutouts(
+            transient,
+            filter_set=Filter.objects.filter(name='PanSTARRS_g')
+        )
         gac_cls = GlobalApertureConstruction(transient_name=transient.name)
 
         status_message = gac_cls._run_process(transient)


### PR DESCRIPTION
Fixes #293  <!-- If your PR relates to an issue mention it here e.g. Issue #34, Issue #56 -->.

## Description of the Change
updates one of the unit tests so that necessary images are available in the S3 backend before proceeding with aperture construction.  Small mod to cutout downloads so that you can select a subset of filters.

## Checklist

Please check all that apply to your proposed changes

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [ ] HTML code change
- [ ] Added package dependency
- [ ] Added data
- [ ] Changed django model
- [ ] Documentation change
- [ ] Added or changed TaskRunner

### **Additional context**
<!-- Add any other context or additional information about the problem here.-->
