### PR TITLE
Display the images in the system pages doc

### DIFF
--- a/docs/developer_guide/dev_system_pages.rst
+++ b/docs/developer_guide/dev_system_pages.rst
@@ -18,7 +18,7 @@ password are set by :code:`DJANGO_SUPERUSER_PASSWORD`
 
 Once logged in, you should see a page like this:
 
-.. image::../_static/django_admin_screenshot.png
+.. image:: ../_static/django_admin_screenshot.png
 
 .. note::
 
@@ -34,7 +34,7 @@ you to see which tasks are being run and which tasks are failing.
 
 Once Blast is running locally to see the Flower dashboard go to `<localhost:8888>`_.
 
-.. image::../_static/flower_dashboard.png
+.. image:: ../_static/flower_dashboard.png
 
 
 RabbitMQ
@@ -51,4 +51,4 @@ password are set by :code:`RABBITMQ_USERNAME`
 
 Once logged in, you see a page like this:
 
-.. image::../_static/rabbitmq_screenshot.png
+.. image:: ../_static/rabbitmq_screenshot.png


### PR DESCRIPTION
Fixes #304   <!-- If your PR relates to an issue mention it here e.g. Issue #34, Issue #56 -->

## Description of the Change
Displays images that were on the [Blast system pages](https://github.com/scimma/blast/blob/main/docs/developer_guide/dev_system_pages.rst) documentation page.

## Checklist

Please check all that apply to your proposed changes

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] HTML code change
- [ ] Added package dependency
- [ ] Added data
- [ ] Changed django model
- [ ] Documentation change
- [ ] Added or changed TaskRunner

### **Additional context**
<!-- Add any other context or additional information about the problem here.-->
