### PR TITLE
Added a loading spinner to the SED plot and inference, and indicate if the data is not available for the same and for aperture information.

### DIFF
--- a/app/host/plotting_utils.py
+++ b/app/host/plotting_utils.py
@@ -27,6 +27,7 @@ from host.prospector import build_obs
 from bokeh.models import CustomJS
 from host.object_store import ObjectStore
 from django.conf import settings
+from bokeh.io import curdoc
 
 # import extinction
 # from bokeh.models import Circle
@@ -290,6 +291,8 @@ def plot_sed(transient=None, sed_results_file=None, type=""):
     if len(flux):
         fig.y_range = Range1d(-0.05 * np.max(flux), 1.5 * np.max(flux))
         fig.x_range = Range1d(np.min(wavelength) * 0.5, np.max(wavelength) * 1.5)
+    else:
+        fig.title = "Data Not Available"
 
     source = ColumnDataSource(
         data=dict(
@@ -323,6 +326,13 @@ def plot_sed(transient=None, sed_results_file=None, type=""):
     ]
     hover = HoverTool(renderers=[p], tooltips=TOOLTIPS, visible=False)
     fig.add_tools(hover)
+
+    # remove the loading spinner
+    hide_loading_indicator = CustomJS(args=dict(), code=f"""
+            document.getElementById('loading-indicator-sed-{type}').style.display = "none";
+            document.getElementById('loading-indicator-sed-inf-{type}').style.display = "none";
+        """)
+    curdoc().js_on_event("document_ready", hide_loading_indicator)
 
     # second check on SED file
     # long-term shouldn't be necessary, just a result of debugging

--- a/app/host/templates/host/photometry_card.html
+++ b/app/host/templates/host/photometry_card.html
@@ -99,6 +99,9 @@
 			{% endfor %}
 		    </tbody>
 		</table>
+        {% if not global_aperture_photometry %}
+        <p>Data not available</p>
+        {% endif %}
             </div>
         </div>
     </div>

--- a/app/host/templates/host/photometry_card.html
+++ b/app/host/templates/host/photometry_card.html
@@ -55,6 +55,9 @@
                         {% endfor %}
                     </tbody>
 		</table>
+        {% if not local_aperture_photometry %}
+        <p>Data not available</p>
+        {% endif %}
             </div>
 	</div>
     </div>

--- a/app/host/templates/host/sed_card.html
+++ b/app/host/templates/host/sed_card.html
@@ -25,6 +25,7 @@
 	  <button style="margin-bottom:5px;" type="button" class="report" onclick="window.open('{% url 'download_modelfit' transient.name 'local' %}','_self')">
             <span>Download Best-Fit Model</span>
             </button>
+            <div id="loading-indicator-sed-local" class="loader"></div>
             {{ bokeh_sed_local_div | safe }}
         </div>
     </div>
@@ -37,7 +38,8 @@
 	    <button style="margin-bottom:5px;" type="button" class="report" onclick="window.open('{% url 'download_modelfit' transient.name 'global' %}','_self')">
             <span>Download Best-Fit Model</span>
             </button>
-          <div>&nbsp;</div>
+            <div>&nbsp;</div>
+            <div id="loading-indicator-sed-global" class="loader"></div>
             {{ bokeh_sed_global_div | safe }}
         </div>
     </div>

--- a/app/host/templates/host/sed_inference_card.html
+++ b/app/host/templates/host/sed_inference_card.html
@@ -26,6 +26,7 @@
             <h4>Local parameter details</h4>
 	    <h6><a href="https://blast.readthedocs.io/en/latest/usage/sed_params.html">Documentation</a></h6>
 	    {% if local_sed_results %}
+        <div id="loading-indicator-sed-inf-local" class="loader"></div>
 	    <div>
 	    <button style="margin-bottom:5px;" type="button" class="report" onclick="window.open('{% url 'download_chains' transient.name 'local' %}','_self')">
               <span>Download Chains</span>
@@ -96,6 +97,8 @@
             </tbody>
             </table>
 	    {% endif %}
+        {% else %}
+        <p>Data not available</p>
 	{% endif %}
         </div>
     </div>
@@ -106,6 +109,7 @@
             <h4>Global parameter details</h4>
 	    <h6><a href="https://blast.readthedocs.io/en/latest/usage/sed_params.html">Documentation</a></h6>
 	    {% if global_sed_results %}
+        <div id="loading-indicator-sed-inf-global" class="loader"></div>
 	    <div>
 	    <button style="margin-bottom:5px;" type="button" class="report" onclick="window.open('{% url 'download_chains' transient.name 'global' %}','_self')">
               <span>Download Chains</span>
@@ -175,7 +179,9 @@
             {% endfor %}
             </tbody>
             </table>
-	    {% endif %}	    
+	    {% endif %}
+        {% else %}
+        <p>Data not available</p>	    
 	{% endif %}
         </div>
     </div>


### PR DESCRIPTION
Fixes #230   <!-- If your PR relates to an issue mention it here e.g. Issue #34, Issue #56 -->.

## Description of the Change
- Adds a loading spinner to the SED plot and SED inference table that is displayed while the bokeh models load.
- Display "Data not available" if there is no data for the SED plot, the SED Inference, and the Aperture Details

## Checklist

Please check all that apply to your proposed changes

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] HTML code change
- [ ] Added package dependency
- [ ] Added data
- [ ] Changed django model
- [ ] Documentation change
- [ ] Added or changed TaskRunner

### **Additional context**
<!-- Add any other context or additional information about the problem here.-->
