### PR TITLE
Move support_email from context to static template tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Blast application will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project (mostly) adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2025-07-02
+
+### Fixed
+
+- The static landing page was not populating the support email address in the email template defined by the `mailto` link in the footer. Instead of supplying the value via context processor, it was supplied via template tag such that the information is available to the periodic rendering function `update_home_page_statistics()`.
+
 ## [1.5.0] - 2025-07-01
 
 ### Added

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -12,7 +12,7 @@ https://docs.djangoproject.com/en/3.2/ref/settings/
 import os
 from pathlib import Path
 
-APP_VERSION = '1.5.0'
+APP_VERSION = '1.5.1'
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent

--- a/app/host/plotting_utils.py
+++ b/app/host/plotting_utils.py
@@ -351,7 +351,7 @@ def plot_sed(transient=None, sed_results_file=None, type=""):
                 cosmo.distmod(result["obs"]["redshift"]).value
                 - cosmo.distmod(result["obs"]["redshift"] - 0.015).value
             )
-            print(f"mag off: {mag_off}")
+            logger.debug(f"mag off: {mag_off}")
             fig.line(
                 a * model_data["rest_wavelength"],
                 maggies_to_mJy(model_data["spec"]) * 10 ** (0.4 * mag_off),

--- a/app/host/templates/host/403.html
+++ b/app/host/templates/host/403.html
@@ -18,7 +18,7 @@
             </p>
             <p>
                 Please
-                <a href="mailto:{{ support_email }}?subject=Blast%20authorization%20request
+                <a href="mailto:{% support_email %}?subject=Blast%20authorization%20request
                     &body=Request authorization to upload new transients to Blast by submitting the information below.
                     %0A%0A
                     Correct missing or inaccurate profile information:

--- a/app/host/templates/host/base.html
+++ b/app/host/templates/host/base.html
@@ -172,7 +172,7 @@
   <footer class="py-3">
     <div class="container">
       <span class="text-muted">
-        <a href="mailto:{{ support_email }}?subject=Blast%20support%20request&body=
+        <a href="mailto:{% support_email %}?subject=Blast%20support%20request&body=
         Please%20provide%20a%20detailed%20description%20of%20your%20problem%20or%20question.%20Make%20sure%20to%20search%20the%20documentation%20%28https%3A%2F%2Fblast.readthedocs.io%29%20and%20our%20GitHub%20Discussions%20%28https%3A%2F%2Fgithub.com%2Fscimma%2Fblast%2Fdiscussions%29%20for%20answers%20first.%20We%20appreciate%20your%20patience%20in%20receiving%20a%20response%3B%20please%20allow%20one%20or%20two%20days%20before%20sending%20a%20follow-up%20email.
         %0A%0A
         &nbsp;&nbsp;&nbsp;&nbsp;Email: {% if user.email %}{{ user.email }}{% endif %}

--- a/app/host/templatetags/host_tags.py
+++ b/app/host/templatetags/host_tags.py
@@ -8,3 +8,8 @@ register = template.Library()
 @register.simple_tag(name="app_version")
 def app_version(prefix):
     return f'''{prefix}{settings.APP_VERSION}'''
+
+
+@register.simple_tag(name="support_email")
+def support_email():
+    return settings.SUPPORT_EMAIL

--- a/app/users/context_processors.py
+++ b/app/users/context_processors.py
@@ -1,5 +1,4 @@
 from django.contrib.auth.context_processors import auth
-from django.conf import settings
 import base64
 import binascii
 from host.log import get_logger
@@ -24,8 +23,5 @@ def user_profile(request):
             break
 
     logger.debug(f'''Decoded username: {username_b64decoded}''')
-    context = {
-        'username_b64decoded': username_b64decoded,
-        'support_email': settings.SUPPORT_EMAIL,
-    }
+    context = {'username_b64decoded': username_b64decoded}
     return context

--- a/app/users/templates/registration/login.html
+++ b/app/users/templates/registration/login.html
@@ -107,7 +107,7 @@ span.psw {
         <br>or you would like to provide feedback about the service,
         <br>please contact Blast support by
         <br><span style="font-size: larger;">
-        <a href="mailto:{{ support_email }}?subject=Blast%20account%20profile%20update
+        <a href="mailto:{% support_email %}?subject=Blast%20account%20profile%20update
                 &body=Request an update to your Blast account profile by correcting missing or inaccurate profile information:
                 %0A%0A
                 &nbsp;&nbsp;&nbsp;&nbsp;Email: {% if user.email %}{{ user.email }}{% else %}[Please enter your preferred email address here.]{% endif %}


### PR DESCRIPTION
Fixes #313 

## Description of the Change

The static landing page was not populating the support email address in the email template defined by the `mailto` link in the footer. Instead of supplying the value via context processor, it was supplied via template tag such that the information is available to the periodic rendering function `update_home_page_statistics()`.