### PR TITLE
Fix SED fit thumbnail bug and GlobalApertureConstruction foreign key violation bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ Types of changes:
 - `Fixed`: for any bug fixes.
 - `Security`: in case of vulnerabilities.
 
+## [1.8.7]
+
+### Fixed
+
+- Reduced the prerequisites for the `GenerateThumbnailSEDLocal` and `GenerateThumbnailSEDGlobal` tasks
+  that were inadvertently preventing SED fit thumbnails from being generated.
+- Fixed a database foreign key constraint violation triggered by the `GlobalApertureConstruction` task
+  that sometimes deleted `Aperture` objects with associated `SEDFittingResult`, `AperturePhotometry`, and/or
+  `StarFormationHistoryResult` objects.
+
 ## [1.8.6]
 
 ### Removed

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -4,7 +4,7 @@ from pathlib import Path
 ######################################################################
 # Blast application config
 #
-APP_VERSION = '1.8.6'
+APP_VERSION = '1.8.7'
 # Data paths
 DUSTMAPS_DATA_ROOT = os.environ.get("DUSTMAPS_DATA_ROOT", "/data/dustmaps")
 CUTOUT_ROOT = os.environ.get("CUTOUT_ROOT", "/data/cutout_cdn")

--- a/app/host/transient_tasks.py
+++ b/app/host/transient_tasks.py
@@ -615,7 +615,7 @@ class GlobalApertureConstruction(TransientTaskRunner):
             "type": "global",
         }
 
-        self._overwrite_or_create_object(Aperture, query, data)
+        create_or_update_aperture(query, data)
         return "processed"
 
 

--- a/app/host/transient_tasks.py
+++ b/app/host/transient_tasks.py
@@ -1526,15 +1526,6 @@ class GenerateThumbnailSEDLocal(GenerateThumbnail):
 
     def _prerequisites(self):
         return {
-            "Cutout download": "processed",
-            "Transient MWEBV": "processed",
-            "Host match": "processed",
-            "Host information": "processed",
-            "Global aperture construction": "processed",
-            "Global aperture photometry": "processed",
-            "Validate global photometry": "processed",
-            "Local aperture photometry": "processed",
-            "Validate local photometry": "processed",
             "Local host SED inference": "processed",
             "Generate thumbnail SED local": "not processed",
         }
@@ -1554,15 +1545,6 @@ class GenerateThumbnailSEDGlobal(GenerateThumbnail):
 
     def _prerequisites(self):
         return {
-            "Cutout download": "processed",
-            "Transient MWEBV": "processed",
-            "Host match": "processed",
-            "Host information": "processed",
-            "Global aperture construction": "processed",
-            "Global aperture photometry": "processed",
-            "Validate global photometry": "processed",
-            "Local aperture photometry": "processed",
-            "Validate local photometry": "processed",
             "Global host SED inference": "processed",
             "Generate thumbnail SED global": "not processed",
         }


### PR DESCRIPTION
Fixes #386 
Fixes #387 

## Description of the Change

### Fixed

- Reduced the prerequisites for the `GenerateThumbnailSEDLocal` and `GenerateThumbnailSEDGlobal` tasks
  that were inadvertently preventing SED fit thumbnails from being generated.
- Fixed a database foreign key constraint violation triggered by the `GlobalApertureConstruction` task
  that sometimes deleted `Aperture` objects with associated `SEDFittingResult`, `AperturePhotometry`, and/or
  `StarFormationHistoryResult` objects.
