### PR TITLE
add host info back to transient api table

### DIFF
--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -17,8 +17,8 @@ class TransientSerializer(serializers.ModelSerializer):
             "tasks_initialized",
             "photometric_class",
             "processing_status",
-            "added_by",
-            "host",
+            "added_by"
+#            "host",
         ]
 
     aliases = serializers.SerializerMethodField()


### PR DESCRIPTION
Fixes #  <!-- If your PR relates to an issue mention it here e.g. Issue #34, Issue #56 -->.
This is a hot fix to allow host information to be linked to transient info in the API.  Possibly we should instead allow hosts to be queryable via associated transient name, but doing it quickly this way to get zooniverse uploads working in advance of teacher workshop next week :)

## Description of the Change

## Checklist

Please check all that apply to your proposed changes

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [ ] HTML code change
- [ ] Added package dependency
- [ ] Added data
- [ ] Changed django model
- [ ] Documentation change
- [ ] Added or changed TaskRunner

### **Additional context**
<!-- Add any other context or additional information about the problem here.-->
