### PR TITLE
Move back-end download functions to /api/sedfittingresult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Types of changes:
 - `Fixed`: for any bug fixes.
 - `Security`: in case of vulnerabilities.
 
+## [x.y.z]
+
+- Added new download functions to /api/sedfittingresult, replacing view functions: download_chains, download_modelfit, download_percentiles
+- Fixed download URLs on /api/sedfittignresult using new download functions, rerouted transient download on front-end to these functions. Functionality from front-end is identical.s
+
+
 ## [1.12.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ Types of changes:
 
 ## [x.y.z]
 
-- Added new download functions to /api/sedfittingresult, replacing view functions: download_chains, download_modelfit, download_percentiles
-- Fixed download URLs on /api/sedfittignresult using new download functions, rerouted transient download on front-end to these functions. Functionality from front-end is identical.s
+- Added new download functions to /api/sedfittingresult, replacing view functions: download_chains, download_modelfit, download_percentiles.
+- New download URL: /api/sedfittingresult/{id}/download/{download-type}/
+- Fixed download URLs on /api/sedfittingresult using new download functions, rerouted transient download on front-end to these functions. Functionality from front-end is identical.
 
 
 ## [1.12.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,9 @@ Types of changes:
 
 ## [x.y.z]
 
-- Added new download functions to /api/sedfittingresult, replacing view functions: download_chains, download_modelfit, download_percentiles.
-- New download URL: /api/sedfittingresult/{id}/download/{download-type}/
-- Fixed download URLs on /api/sedfittingresult using new download functions, rerouted transient download on front-end to these functions. Functionality from front-end is identical.
+- Added new download functions to `/api/sedfittingresult`, replacing view functions: `download_chains`, `download_modelfit`, `download_percentiles`.
+- New download URL: `/api/sedfittingresult/{id}/download/{download-type}/`
+- Fixed download URLs on `/api/sedfittingresult` using new download functions, rerouted transient download on front-end to these functions. Functionality from front-end is identical.
 
 
 ## [1.12.0]

--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -1,5 +1,6 @@
 from host import models
 from rest_framework import serializers
+from django.urls import reverse
 
 
 class CutoutField(serializers.RelatedField):
@@ -18,7 +19,6 @@ class TransientSerializer(serializers.ModelSerializer):
             "photometric_class",
             "processing_status",
             "added_by"
-#            "host",
         ]
 
     aliases = serializers.SerializerMethodField()
@@ -81,10 +81,61 @@ class AliasSerializer(serializers.ModelSerializer):
 
 
 class SEDFittingResultSerializer(serializers.ModelSerializer):
+    chains_file = serializers.SerializerMethodField()
+    model_file = serializers.SerializerMethodField()
+    percentiles_file = serializers.SerializerMethodField()
     class Meta:
         model = models.SEDFittingResult
         depth = 1
         exclude = ["log_tau_16", "log_tau_50", "log_tau_84", "posterior"]
+
+    def to_representation(self, instance):
+    #     """Hardcode download URL"""
+        ret = super().to_representation(instance)
+        ret['chains_file'] = self.get_chains_file(instance)
+        ret['model_file'] = self.get_model_file(instance)
+        ret['percentiles_file'] = self.get_percentiles_file(instance)
+        
+        return ret
+    
+    def get_chains_file(self, obj):
+        request = self.context["request"]
+
+        return request.build_absolute_uri(
+            reverse(
+                "sedfittingresult-download",
+                kwargs={
+                    "pk": obj.pk,
+                    "file_type": "chains",
+                },
+            )
+        )
+    
+    def get_model_file(self, obj):
+        request = self.context["request"]
+
+        return request.build_absolute_uri(
+            reverse(
+                "sedfittingresult-download",
+                kwargs={
+                    "pk": obj.pk,
+                    "file_type": "model",
+                },
+            )
+        )
+
+    def get_percentiles_file(self, obj):
+        request = self.context["request"]
+
+        return request.build_absolute_uri(
+            reverse(
+                "sedfittingresult-download",
+                kwargs={
+                    "pk": obj.pk,
+                    "file_type": "percentiles",
+                },
+            )
+        )
 
 
 class CutoutSerializer(serializers.ModelSerializer):

--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -79,12 +79,16 @@ class AliasSerializer(serializers.ModelSerializer):
     def get_host(self, obj):
         return obj.host.name if obj.host else None
 
+class DownloadURLField(serializers.SerializerMethodField):
+    #Like SerializerMethodField, but also passes self.field_name to the method, avoid hardcoding per-field wrappers.
+    def to_representation(self, obj):
+        method = getattr(self.parent, self.method_name)
+        return method(obj, self.field_name)
 
 class SEDFittingResultSerializer(serializers.ModelSerializer):
-    chains_file = serializers.SerializerMethodField()
-    model_file = serializers.SerializerMethodField()
-    percentiles_file = serializers.SerializerMethodField()
-
+    chains_file = DownloadURLField(method_name='get_download_file')
+    model_file = DownloadURLField(method_name='get_download_file')
+    percentiles_file = DownloadURLField(method_name='get_download_file')
     class Meta:
         model = models.SEDFittingResult
         depth = 1
@@ -93,46 +97,15 @@ class SEDFittingResultSerializer(serializers.ModelSerializer):
     def to_representation(self, instance):
         # Hardcode download URL
         ret = super().to_representation(instance)
-        ret['chains_file'] = self.get_chains_file(instance)
-        ret['model_file'] = self.get_model_file(instance)
-        ret['percentiles_file'] = self.get_percentiles_file(instance)
+        ret['chains_file'] = self.get_download_file(instance, "chains")
+        ret['model_file'] = self.get_download_file(instance, "model")
+        ret['percentiles_file'] = self.get_download_file(instance, "percentiles")
         return ret
-
-    def get_chains_file(self, obj):
-        request = self.context["request"]
-
-        return request.build_absolute_uri(
-            reverse(
-                "sedfittingresult-download",
-                kwargs={
-                    "pk": obj.pk,
-                    "file_type": "chains",
-                },
-            )
-        )
-
-    def get_model_file(self, obj):
+    
+    def get_download_file(self, obj, file_type):
         request = self.context["request"]
         return request.build_absolute_uri(
-            reverse(
-                "sedfittingresult-download",
-                kwargs={
-                    "pk": obj.pk,
-                    "file_type": "model",
-                },
-            )
-        )
-
-    def get_percentiles_file(self, obj):
-        request = self.context["request"]
-        return request.build_absolute_uri(
-            reverse(
-                "sedfittingresult-download",
-                kwargs={
-                    "pk": obj.pk,
-                    "file_type": "percentiles",
-                },
-            )
+            reverse("sedfittingresult-download", kwargs={"pk": obj.pk, "file_type": file_type})
         )
 
 

--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -84,20 +84,20 @@ class SEDFittingResultSerializer(serializers.ModelSerializer):
     chains_file = serializers.SerializerMethodField()
     model_file = serializers.SerializerMethodField()
     percentiles_file = serializers.SerializerMethodField()
+
     class Meta:
         model = models.SEDFittingResult
         depth = 1
         exclude = ["log_tau_16", "log_tau_50", "log_tau_84", "posterior"]
 
     def to_representation(self, instance):
-    #     """Hardcode download URL"""
+        # Hardcode download URL
         ret = super().to_representation(instance)
         ret['chains_file'] = self.get_chains_file(instance)
         ret['model_file'] = self.get_model_file(instance)
         ret['percentiles_file'] = self.get_percentiles_file(instance)
-        
         return ret
-    
+
     def get_chains_file(self, obj):
         request = self.context["request"]
 
@@ -110,10 +110,9 @@ class SEDFittingResultSerializer(serializers.ModelSerializer):
                 },
             )
         )
-    
+
     def get_model_file(self, obj):
         request = self.context["request"]
-
         return request.build_absolute_uri(
             reverse(
                 "sedfittingresult-download",
@@ -126,7 +125,6 @@ class SEDFittingResultSerializer(serializers.ModelSerializer):
 
     def get_percentiles_file(self, obj):
         request = self.context["request"]
-
         return request.build_absolute_uri(
             reverse(
                 "sedfittingresult-download",

--- a/app/api/views.py
+++ b/app/api/views.py
@@ -13,9 +13,10 @@ from django.http import JsonResponse
 from django.shortcuts import render
 from django_filters.rest_framework import DjangoFilterBackend
 from django.contrib.auth.decorators import login_required, permission_required
+from django.shortcuts import get_object_or_404
 from rest_framework import status
 from rest_framework import viewsets
-from rest_framework.decorators import api_view
+from rest_framework.decorators import api_view, action
 from rest_framework.response import Response
 from host.object_store import ObjectStore
 from host.models import Aperture
@@ -47,6 +48,16 @@ from api.components import data_model_components
 
 from host.log import get_logger
 logger = get_logger(__name__)
+
+def stream_download_file(file_path):
+    # Stream the data file from the S3 bucket
+    s3 = ObjectStore()
+    object_key = os.path.join(settings.S3_BASE_PATH, file_path.strip('/'))
+    filename = os.path.basename(file_path)
+    obj_stream = s3.stream_object(object_key)
+    response = StreamingHttpResponse(streaming_content=obj_stream)
+    response["Content-Disposition"] = f"attachment; filename={filename}"
+    return response
 
 
 ############################################################
@@ -188,6 +199,19 @@ class SEDFittingResultViewSet(viewsets.ReadOnlyModelViewSet):
     filter_backends = (DjangoFilterBackend,)
     filterset_class = SEDFittingResultFilter
 
+    @action(methods=['get'], detail=True, url_path=r"download/(?P<file_type>[^/.]+)")
+    def download(self, request, pk=None, file_type=None):
+        sed_result = self.get_object()
+        if file_type == 'chains':
+            file_field = sed_result.chains_file
+        elif file_type == 'model':
+            file_field = sed_result.model_file
+        elif file_type == 'percentiles':
+            file_field = sed_result.percentiles_file
+        else:
+            return Response({'error':"unknown file type"}, status=400)
+        
+        return stream_download_file(file_field.name)
 
 class TaskRegisterViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = TaskRegister.objects.all()

--- a/app/api/views.py
+++ b/app/api/views.py
@@ -13,7 +13,6 @@ from django.http import JsonResponse
 from django.shortcuts import render
 from django_filters.rest_framework import DjangoFilterBackend
 from django.contrib.auth.decorators import login_required, permission_required
-from django.shortcuts import get_object_or_404
 from rest_framework import status
 from rest_framework import viewsets
 from rest_framework.decorators import api_view, action
@@ -48,6 +47,7 @@ from api.components import data_model_components
 
 from host.log import get_logger
 logger = get_logger(__name__)
+
 
 def stream_download_file(file_path):
     # Stream the data file from the S3 bucket
@@ -209,9 +209,9 @@ class SEDFittingResultViewSet(viewsets.ReadOnlyModelViewSet):
         elif file_type == 'percentiles':
             file_field = sed_result.percentiles_file
         else:
-            return Response({'error':"unknown file type"}, status=400)
-        
+            return Response({'error': "unknown file type"}, status=400)
         return stream_download_file(file_field.name)
+
 
 class TaskRegisterViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = TaskRegister.objects.all()

--- a/app/api/views.py
+++ b/app/api/views.py
@@ -199,17 +199,14 @@ class SEDFittingResultViewSet(viewsets.ReadOnlyModelViewSet):
     filter_backends = (DjangoFilterBackend,)
     filterset_class = SEDFittingResultFilter
 
+    allowed_file_types = {'chains', 'model', 'percentiles'}
+
     @action(methods=['get'], detail=True, url_path=r"download/(?P<file_type>[^/.]+)")
     def download(self, request, pk=None, file_type=None):
-        sed_result = self.get_object()
-        if file_type == 'chains':
-            file_field = sed_result.chains_file
-        elif file_type == 'model':
-            file_field = sed_result.model_file
-        elif file_type == 'percentiles':
-            file_field = sed_result.percentiles_file
-        else:
+        if file_type not in self.allowed_file_types:
             return Response({'error': "unknown file type"}, status=400)
+        sed_result = self.get_object()
+        file_field = getattr(sed_result, f"{file_type}_file")
         return stream_download_file(file_field.name)
 
 

--- a/app/host/static/robots.txt
+++ b/app/host/static/robots.txt
@@ -1,9 +1,6 @@
 User-agent: *
 Disallow: /transient/
 Disallow: /add/
-Disallow: /download_chains/
-Disallow: /download_modelfit/
-Disallow: /download_percentiles/
 Disallow: /retrigger_transient/
 Disallow: /reprocess_transient/
 Disallow: /report_issue/

--- a/app/host/templates/host/sed_card.html
+++ b/app/host/templates/host/sed_card.html
@@ -63,11 +63,6 @@
                 }
             </script>
             {% endif %}
-            <!--
-            <button style="margin-bottom:5px;" type="button" class="report" onclick="window.open('{% url 'download_modelfit' transient.name 'local' %}','_self')">
-                <span>Download Best-Fit Model</span>
-            </button>
-            -->
         </div>
     </div>
 
@@ -120,11 +115,6 @@
                 }
             </script>
             {% endif %}
-            <!--
-            <button style="margin-bottom:5px;" type="button" class="report" onclick="window.open('{% url 'download_modelfit' transient.name 'global' %}','_self')">
-                <span>Download Best-Fit Model</span>
-            </button>
-             -->
         </div>
     </div>
 </div>

--- a/app/host/templates/host/sed_inference_card.html
+++ b/app/host/templates/host/sed_inference_card.html
@@ -24,16 +24,6 @@
             <h4>Local parameter details</h4>
         <h6><a href="https://blast.readthedocs.io/en/latest/usage/sed_params.html">Documentation</a></h6>
         {% if local_sed_results %}
-        <!--
-        <div>
-        <button style="margin-bottom:5px;" type="button" class="report" onclick="window.open('{% url 'download_chains' transient.name 'local' %}','_self')">
-            <span>Download Chains</span>
-        </button>
-        <button style="margin-bottom:5px;" type="button" class="report" onclick="window.open('{% url 'download_percentiles' transient.name 'local' %}','_self')">
-            <span>Download Percentiles</span>
-        </button>
-        </div>
-        -->
 
             <br>
 
@@ -108,16 +98,6 @@
             <h4>Global parameter details</h4>
         <h6><a href="https://blast.readthedocs.io/en/latest/usage/sed_params.html">Documentation</a></h6>
         {% if global_sed_results %}
-        <!--
-        <div>
-        <button style="margin-bottom:5px;" type="button" class="report" onclick="window.open('{% url 'download_chains' transient.name 'global' %}','_self')">
-            <span>Download Chains</span>
-        </button>
-        <button style="margin-bottom:5px;" type="button" class="report" onclick="window.open('{% url 'download_percentiles' transient.name 'global' %}','_self')">
-            <span>Download Percentiles</span>
-        </button>
-        </div>
-        -->
 
             <br>
 

--- a/app/host/templates/host/transient_actions.html
+++ b/app/host/templates/host/transient_actions.html
@@ -14,15 +14,15 @@
     <a class="dropdown-item" title="Export without files (legacy)" href="/api/transient/get/{{transient.name}}?format=json"><i class="bi bi-filetype-json"></i> Export without files (legacy .json)</a>
     {% if local_sed_results %}
     <div class="dropdown-divider"></div>
-    <a class="dropdown-item" title="Local parameter confidence intervals" href="{% url 'download_modelfit' transient.name 'local' %}"><i class="bi bi-graph-up"></i> Local SED best-fit model (.npz)</a>
-    <a class="dropdown-item" title="Local parameter confidence intervals" href="{% url 'download_percentiles' transient.name 'local' %}"><i class="bi bi-percent"></i> Local parameter confidence intervals (.npz)</a>
-    <a class="dropdown-item" title="Local parameter estimation chains" href="{% url 'download_chains' transient.name 'local' %}"><i class="bi bi-link"></i> Local parameter estimation chains (.npz)</a>
+    <a class="dropdown-item" title="Local SED best-fit model" href="{% url 'sedfittingresult-download' transient.id 'model' %}"><i class="bi bi-graph-up"></i> Local SED best-fit model (.npz)</a>
+    <a class="dropdown-item" title="Local parameter confidence intervals" href="{% url 'sedfittingresult-download' transient.id 'percentiles' %}"><i class="bi bi-percent"></i> Local parameter confidence intervals (.npz)</a>
+    <a class="dropdown-item" title="Local parameter estimation chains" href="{% url 'sedfittingresult-download' transient.id 'chains' %}"><i class="bi bi-link"></i> Local parameter estimation chains (.npz)</a>
     {% endif %}
     {% if global_sed_results %}
     <div class="dropdown-divider"></div>
-    <a class="dropdown-item" title="Global parameter confidence intervals" href="{% url 'download_modelfit' transient.name 'global' %}"><i class="bi bi-graph-up"></i> Global SED best-fit model (.npz)</a>
-    <a class="dropdown-item" title="Global parameter confidence intervals" href="{% url 'download_percentiles' transient.name 'global' %}"><i class="bi bi-percent"></i> Global parameter confidence intervals (.npz)</a>
-    <a class="dropdown-item" title="Global parameter estimation chains" href="{% url 'download_chains' transient.name 'global' %}"><i class="bi bi-link"></i> Global parameter estimation chains (.npz)</a>
+    <a class="dropdown-item" title=Global SED best-fit model" href="{% url 'sedfittingresult-download' transient.id 'model' %}"><i class="bi bi-graph-up"></i> Global SED best-fit model (.npz)</a>
+    <a class="dropdown-item" title="Global parameter confidence intervals" href="{% url 'sedfittingresult-download' transient.id 'percentiles' %}"><i class="bi bi-percent"></i> Global parameter confidence intervals (.npz)</a>
+    <a class="dropdown-item" title="Global parameter estimation chains" href="{% url 'sedfittingresult-download' transient.id 'chains' %}"><i class="bi bi-link"></i> Global parameter estimation chains (.npz)</a>
     {% endif %}
   </div>
 </li>

--- a/app/host/urls.py
+++ b/app/host/urls.py
@@ -21,21 +21,6 @@ urlpatterns = [
     path(f"""{base_path}transients/""", views.transient_list, name="transient_list"),
     path(f"""{base_path}add/""", views.add_transient, name="add_transient"),
     path(f"""{base_path}transients/<slug:transient_name>/""", views.results, name="results"),
-    path(
-        f"""{base_path}download_chains/<slug:slug>/<str:aperture_type>/""",
-        views.download_chains,
-        name="download_chains",
-    ),
-    path(
-        f"""{base_path}download_modelfit/<slug:slug>/<str:aperture_type>/""",
-        views.download_modelfit,
-        name="download_modelfit",
-    ),
-    path(
-        f"""{base_path}download_percentiles/<slug:slug>/<str:aperture_type>/""",
-        views.download_percentiles,
-        name="download_percentiles",
-    ),
     path(f"""{base_path}acknowledgements/""", views.acknowledgements, name="acknowledgements"),
     path(f"""{base_path}team/""", views.team, name="team"),
     path(f"""{base_path}""", views.home),
@@ -72,7 +57,7 @@ router.register(r"aperture", api.views.ApertureViewSet)
 router.register(r"cutout", api.views.CutoutViewSet)
 router.register(r"filter", api.views.FilterViewSet)
 router.register(r"aperturephotometry", api.views.AperturePhotometryViewSet)
-router.register(r"sedfittingresult", api.views.SEDFittingResultViewSet)
+router.register(r"sedfittingresult", api.views.SEDFittingResultViewSet, basename="sedfittingresult")
 router.register(r"taskregister", api.views.TaskRegisterViewSet)
 router.register(r"task", api.views.TaskViewSet)
 router.register(r"host", api.views.HostViewSet)

--- a/app/host/views.py
+++ b/app/host/views.py
@@ -634,41 +634,6 @@ def results(request, transient_name):
     return render(request, "results.html", context)
 
 
-def stream_sed_output_file(file_path):
-    # Stream the data file from the S3 bucket
-    s3 = ObjectStore()
-    object_key = os.path.join(settings.S3_BASE_PATH, file_path.strip('/'))
-    filename = os.path.basename(file_path)
-    obj_stream = s3.stream_object(object_key)
-    response = StreamingHttpResponse(streaming_content=obj_stream)
-    response["Content-Disposition"] = f"attachment; filename={filename}"
-    return response
-
-
-@log_usage_metric()
-def download_chains(request, slug, aperture_type):
-    sed_result = get_object_or_404(
-        SEDFittingResult, transient__name=slug, aperture__type=aperture_type
-    )
-    return stream_sed_output_file(sed_result.chains_file.name)
-
-
-@log_usage_metric()
-def download_modelfit(request, slug, aperture_type):
-    sed_result = get_object_or_404(
-        SEDFittingResult, transient__name=slug, aperture__type=aperture_type
-    )
-    return stream_sed_output_file(sed_result.model_file.name)
-
-
-@log_usage_metric()
-def download_percentiles(request, slug, aperture_type):
-    sed_result = get_object_or_404(
-        SEDFittingResult, transient__name=slug, aperture__type=aperture_type
-    )
-    return stream_sed_output_file(sed_result.percentiles_file.name)
-
-
 @log_usage_metric()
 def acknowledgements(request):
     context = {}

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -31,4 +31,11 @@ server {
 		alias /static/robots.txt;
 	}
 
+	location /api {
+		proxy_pass http://app/api;
+		proxy_set_header Host $host:4000 ;
+
+		# See the reasoning above for customizing the header
+		# Correct download url showing up in api serialized output
+	}
 }

--- a/nginx/default_slim.conf
+++ b/nginx/default_slim.conf
@@ -31,4 +31,11 @@ server {
 		alias /static/robots.txt;
 	}
 
+	location /api {
+		proxy_pass http://app/api;
+		proxy_set_header Host $host:4000 ;
+
+		# See the reasoning above for customizing the header
+		# Correct download url showing up in api serialized output
+	}
 }


### PR DESCRIPTION
Resolves #411 

- Added new download functions to /api/sedfittingresult, replacing view functions: download_chains, download_modelfit, download_percentiles
- New download URL: /api/sedfittingresult/{id}/download/{download-type}/
- Fixed download URLs on /api/sedfittingresult using new download functions, rerouted transient download on front-end to these functions. Functionality from front-end is identical