### PR TITLE
FITS Cutout Download Implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Types of changes:
 - `Fixed`: for any bug fixes.
 - `Security`: in case of vulnerabilities.
 
+## [x.y.z]
+- Added new cutout download function to CutoutViewSet
+- Cutout serialization in `/api/cutout` has added field with download URL for available cutouts
+- Transient results page now has download links next to each available filter under 'Cutout Download Report'
+
 ## [1.12.0]
 
 ### Added

--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -1,6 +1,6 @@
 from host import models
 from rest_framework import serializers
-
+from django.urls import reverse
 
 class CutoutField(serializers.RelatedField):
     def to_representation(self, value):
@@ -18,7 +18,6 @@ class TransientSerializer(serializers.ModelSerializer):
             "photometric_class",
             "processing_status",
             "added_by"
-#            "host",
         ]
 
     aliases = serializers.SerializerMethodField()
@@ -88,10 +87,28 @@ class SEDFittingResultSerializer(serializers.ModelSerializer):
 
 
 class CutoutSerializer(serializers.ModelSerializer):
+    cutout_file = serializers.SerializerMethodField()
     class Meta:
         model = models.Cutout
         depth = 1
         exclude = ["fits"]
+
+    def to_representation(self, instance):
+        ret = super().to_representation(instance)
+        ret['cutout_file'] = self.get_cutout_file(instance)
+        return ret
+    
+    def get_cutout_file(self, obj):
+        request = self.context["request"]
+        if not obj.fits:
+            return None
+        
+        return request.build_absolute_uri(
+            reverse(
+                "cutout-download",
+                kwargs={"pk":obj.pk,}
+            )
+        )
 
 
 class FilterSerializer(serializers.ModelSerializer):

--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -18,6 +18,7 @@ class TransientSerializer(serializers.ModelSerializer):
             "photometric_class",
             "processing_status",
             "added_by"
+            # "host",
         ]
 
     aliases = serializers.SerializerMethodField()

--- a/app/api/views.py
+++ b/app/api/views.py
@@ -48,6 +48,7 @@ from api.components import data_model_components
 from host.log import get_logger
 logger = get_logger(__name__)
 
+
 def stream_download_file(file_path):
     # Stream the data file from the S3 bucket
     s3 = ObjectStore()
@@ -60,6 +61,7 @@ def stream_download_file(file_path):
 
 ############################################################
 # Filter Sets
+
 
 class TransientFilter(django_filters.FilterSet):
     redshift_lte = django_filters.NumberFilter(
@@ -180,6 +182,7 @@ class CutoutViewSet(viewsets.ReadOnlyModelViewSet):
     def download(self, request, pk=None):
         cutout = self.get_object()
         return stream_download_file(cutout.fits.name)
+
 
 class FilterViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Filter.objects.all()

--- a/app/api/views.py
+++ b/app/api/views.py
@@ -15,7 +15,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from django.contrib.auth.decorators import login_required, permission_required
 from rest_framework import status
 from rest_framework import viewsets
-from rest_framework.decorators import api_view
+from rest_framework.decorators import api_view, action
 from rest_framework.response import Response
 from host.object_store import ObjectStore
 from host.models import Aperture
@@ -48,6 +48,15 @@ from api.components import data_model_components
 from host.log import get_logger
 logger = get_logger(__name__)
 
+def stream_download_file(file_path):
+    # Stream the data file from the S3 bucket
+    s3 = ObjectStore()
+    object_key = os.path.join(settings.S3_BASE_PATH, file_path.strip('/'))
+    filename = os.path.basename(file_path)
+    obj_stream = s3.stream_object(object_key)
+    response = StreamingHttpResponse(streaming_content=obj_stream)
+    response["Content-Disposition"] = f"attachment; filename={filename}"
+    return response
 
 ############################################################
 # Filter Sets
@@ -167,6 +176,10 @@ class CutoutViewSet(viewsets.ReadOnlyModelViewSet):
     filter_backends = (DjangoFilterBackend,)
     filterset_class = CutoutFilter
 
+    @action(methods=['get'], detail=True, url_path="download")
+    def download(self, request, pk=None):
+        cutout = self.get_object()
+        return stream_download_file(cutout.fits.name)
 
 class FilterViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Filter.objects.all()

--- a/app/host/templates/host/cutout_status_card.html
+++ b/app/host/templates/host/cutout_status_card.html
@@ -6,23 +6,24 @@
 
 <!-- body -->
 {% block body %}
-<table class="table table-sm" style="text-align: center;">
+<table class="table table-sm" style="text-align: right;">
   <thead style="font-size:1.3rem;">
-    <th colspan="2"><i class="bi bi-check" , style="font-size: 2rem; color: green; vertical-align: middle;"></i> Downloadable</th>
+    <th><i class="bi bi-check" , style="font-size: 2rem; color: green; vertical-align: middle;"></i> Downloadable</th>
     <th><i class="bi bi-x" , style="font-size: 2rem; color: red; vertical-align: middle;"></i> Unavailable</th>
   </thead>
   <tbody style="font-family: monospace;">
     <tr>
       <td style="color: green;">
-        {% for filter, status in filter_status.items %}{% if status == "yes"%}{{filter}}<br />{% endif %}{% endfor %}
-      </td>
-      <td>
-        {% for filter, status in filter_status.items %}{% if status == "yes"%}
+      {% for filter, status in filter_status.items %}
         {% with cutout_id=cutout_ids|get_item:filter %}
-        <a href="{% url 'cutout-download' cutout_id %}"><i class="btn"></i> Download
-        </a>
-        <br />{% endwith %}{% endif %}{% endfor %}
-      </td> 
+          {% if status == "yes"%}
+            <a href="{% url 'cutout-download' cutout_id %}" style="color: green;" title="Download image">
+              {{filter}} <i class="bi bi-download"></i>
+            </a><br />
+          {% endif %}
+        {% endwith %}
+      {% endfor %}
+      </td>
       <td style="color: red;">
         {% for filter, status in filter_status.items %}{% if status != "yes"%}{{filter}}<br />{% endif %}{% endfor %}
       </td>

--- a/app/host/templates/host/cutout_status_card.html
+++ b/app/host/templates/host/cutout_status_card.html
@@ -1,4 +1,5 @@
 {% extends "host/card_template.html" %}
+{% load host_tags %}
 
 <!-- title -->
 {% block title %}<h4>Cutout Download Report</h4>{% endblock %}
@@ -7,7 +8,7 @@
 {% block body %}
 <table class="table table-sm" style="text-align: center;">
   <thead style="font-size:1.3rem;">
-    <th><i class="bi bi-check" , style="font-size: 2rem; color: green; vertical-align: middle;"></i> Downloaded</th>
+    <th colspan="2"><i class="bi bi-check" , style="font-size: 2rem; color: green; vertical-align: middle;"></i> Downloadable</th>
     <th><i class="bi bi-x" , style="font-size: 2rem; color: red; vertical-align: middle;"></i> Unavailable</th>
   </thead>
   <tbody style="font-family: monospace;">
@@ -15,6 +16,13 @@
       <td style="color: green;">
         {% for filter, status in filter_status.items %}{% if status == "yes"%}{{filter}}<br />{% endif %}{% endfor %}
       </td>
+      <td>
+        {% for filter, status in filter_status.items %}{% if status == "yes"%}
+        {% with cutout_id=cutout_ids|get_item:filter %}
+        <a href="{% url 'cutout-download' cutout_id %}"><i class="btn"></i> Download
+        </a>
+        <br />{% endwith %}{% endif %}{% endfor %}
+      </td> 
       <td style="color: red;">
         {% for filter, status in filter_status.items %}{% if status != "yes"%}{{filter}}<br />{% endif %}{% endfor %}
       </td>

--- a/app/host/templatetags/host_tags.py
+++ b/app/host/templatetags/host_tags.py
@@ -13,3 +13,7 @@ def app_version(prefix):
 @register.simple_tag(name="support_email")
 def support_email():
     return settings.SUPPORT_EMAIL
+
+@register.filter
+def get_item(dictionary, key):
+    return dictionary.get(key)

--- a/app/host/urls.py
+++ b/app/host/urls.py
@@ -69,7 +69,7 @@ router = DefaultRouter()
 
 router.register(r"transient", api.views.TransientViewSet)
 router.register(r"aperture", api.views.ApertureViewSet)
-router.register(r"cutout", api.views.CutoutViewSet)
+router.register(r"cutout", api.views.CutoutViewSet, basename="cutout")
 router.register(r"filter", api.views.FilterViewSet)
 router.register(r"aperturephotometry", api.views.AperturePhotometryViewSet)
 router.register(r"sedfittingresult", api.views.SEDFittingResultViewSet)

--- a/app/host/views.py
+++ b/app/host/views.py
@@ -615,7 +615,7 @@ def results(request, transient_name):
             "host_aliases": ', '.join([alias.alias for alias in host_aliases]),
             "filter_select_form": filter_select_form,
             "filter_status": filter_status,
-            "cutout_ids" : cutout_ids,
+            "cutout_ids": cutout_ids,
             "local_aperture": local_aperture[0] if local_aperture.exists() else None,
             "global_aperture": global_aperture[0] if global_aperture.exists() else None,
             "local_sed_results": compile_sed_results(transient, 'base', 'local'),

--- a/app/host/views.py
+++ b/app/host/views.py
@@ -516,6 +516,10 @@ def results(request, transient_name):
         filter_.name: ("yes" if filter_.name in filters else "no")
         for filter_ in Filter.objects.all()
     }
+    cutout_ids = {
+        cutout.filter.name: cutout.pk
+        for cutout in all_cutouts
+    }
 
     # Compile aperture details
     global_aperture = select_aperture(transient)
@@ -611,6 +615,7 @@ def results(request, transient_name):
             "host_aliases": ', '.join([alias.alias for alias in host_aliases]),
             "filter_select_form": filter_select_form,
             "filter_status": filter_status,
+            "cutout_ids" : cutout_ids,
             "local_aperture": local_aperture[0] if local_aperture.exists() else None,
             "global_aperture": global_aperture[0] if global_aperture.exists() else None,
             "local_sed_results": compile_sed_results(transient, 'base', 'local'),

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -31,4 +31,12 @@ server {
 		alias /static/robots.txt;
 	}
 
+	location /api {
+		proxy_pass http://app/api;
+		proxy_set_header Host $host:4000 ;
+
+		# See the reasoning above for customizing the header
+		# Correct download url showing up in api serialized output
+	}
+
 }

--- a/nginx/default_slim.conf
+++ b/nginx/default_slim.conf
@@ -31,4 +31,12 @@ server {
 		alias /static/robots.txt;
 	}
 
+	location /api {
+		proxy_pass http://app/api;
+		proxy_set_header Host $host:4000 ;
+
+		# See the reasoning above for customizing the header
+		# Correct download url showing up in api serialized output
+	}
+
 }


### PR DESCRIPTION
Fixes #306 

- Added new cutout download function to CutoutViewSet, contained in Blast API
- Cutout serialization in `/api/cutout` has added field with download URL for available cutouts
- Transient results page now has download links next to each available filter under 'Cutout Download Report'
